### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The agents involved in the collaboration include:
 
 1. Ensure required libraries are installed:
 ```
-pip install pyautogen
+pip install ag2
 ```
 
 2. Set up the OpenAI configuration list by either providing an environment variable `OAI_CONFIG_LIST` or specifying a file path.

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ numpy==1.26.0
 openai==0.28.1
 packaging==23.2
 pkginfo==1.9.6
-pyautogen==0.1.5
+ag2==0.1.5
 pycodestyle==2.11.0
 pydantic==2.4.2
 pydantic_core==2.10.1


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
